### PR TITLE
S3 subfolders, Lambda compatibility, automatic gzip content handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,5 @@ fus3.init(function(){
 ```
 
 
-A temp folder './.tmp/fetch_upload_s3' is used as a proxy.
+A temp folder '/tmp/fetch_upload_s3' is used as a proxy.
 Temporary and source files are deleted locally as soon as they have been uploaded to S3

--- a/README.md
+++ b/README.md
@@ -3,14 +3,22 @@ fetch-upload-s3
 
 Fetches an asset (picture for instance) from a remote URL (or a local file) and uploads it to Amazon S3.
 
-## install
+## Install
 
 ```javascript
-npm install fetch-upload-s3
+npm install --save Buyerquest/fetch-upload-s3
 ```
 
-## setup
-### credentials
+## Setup
+
+### Credentials
+
+#### AWS Lambda
+
+If you're running on Lambda, the AWS SDK will automatically use the IAM role. This behavior cannot be configured.
+
+#### Elsewhere
+
 Create app environment variables and set
 
 `AWS_ACCESS_KEY_ID`
@@ -19,26 +27,31 @@ Create app environment variables and set
 
 `AWS_REGION`
 
-You can use different bucket name depending on your environment.
-
-## use
+## Example
 
 ```javascript
+// To fetch the file at URL: http://nodejs.org/images/logo.png
+// And then a file and upload it to S3 at the path: s3://my-s3-bucket/path/inside/bucket/file.ext
 var FUS3 = require('fetch-upload-s3');
+var fus3 = new FUS3('my-s3-bucket');
 
-var fus3 = new FUS3('my_aws_bucket');
-
-// For fetch url :
-fus3.init(function(){
-  fus3.do('http://nodejs.org/images/logo.png', 'my_key', function(err, data){
-    console.log('file uploaded to S3!');
+fus3.init(function() {
+  fus3.do('http://nodejs.org/images/logo.png', 'path/inside/bucket/file.ext', function(err, data) {
+    console.log('file fetched and uploaded to S3!');
     console.log(data);
+    console.log(err);
   });
 });
+};
+```
 
-// for upload File :
+```javascript
+// To upload a file that already exists on your local file system to S3 at the path: s3://my-s3-bucket/path/inside/bucket/file.ext
+var FUS3 = require('fetch-upload-s3');
+var fus3 = new FUS3('my-s3-bucket');
+
 fus3.init(function(){
-  fus3.uploadFile(absoluteFilePath, 'my_key',
+  fus3.uploadFile('/path/to/local/file', 'path/inside/bucket/file.ext',
     function(err, data){
     console.log('file uploaded to S3!');
     console.log(data);
@@ -46,6 +59,7 @@ fus3.init(function(){
 });
 ```
 
+## Notes
 
 A temp folder '/tmp/fetch_upload_s3' is used as a proxy.
 Temporary and source files are deleted locally as soon as they have been uploaded to S3

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Create app environment variables and set
 
 ```javascript
 // To fetch the file at URL: http://nodejs.org/images/logo.png
-// And then a file and upload it to S3 at the path: s3://my-s3-bucket/path/inside/bucket/file.ext
+// And then upload it to S3 at the path: s3://my-s3-bucket/path/inside/bucket/file.ext
 var FUS3 = require('fetch-upload-s3');
 var fus3 = new FUS3('my-s3-bucket');
 

--- a/lib/bucket.js
+++ b/lib/bucket.js
@@ -1,11 +1,15 @@
 var AWS = require('aws-sdk'),
     fs = require('fs');
+var isLambda = require('is-lambda')
+
+if (!isLambda) {
 
 AWS.config.update({
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
     region: process.env.AWS_REGION
 });
+}
 
 var S3Bucket = function(bucket_name) {
   this.bucket = new AWS.S3({params: {Bucket: bucket_name}});

--- a/lib/download.js
+++ b/lib/download.js
@@ -1,16 +1,49 @@
 var fs = require('fs'),
-    request = require('request');
+    got = require('got'),
+    path = require('path');
+
+function mkDirByPathSync(targetDir, {isRelativeToScript = false} = {}) {
+  const sep = path.sep;
+  const initDir = path.isAbsolute(targetDir) ? sep : '';
+  const baseDir = isRelativeToScript ? __dirname : '.';
+
+  targetDir.split(sep).reduce((parentDir, childDir) => {
+    const curDir = path.resolve(baseDir, parentDir, childDir);
+    try {
+      fs.mkdirSync(curDir);
+    } catch (err) {
+      if (err.code !== 'EEXIST') {
+        throw err;
+      }
+
+    }
+
+    return curDir;
+  }, initDir);
+}
 
 module.exports = function(uri, filename, done) {
-    var r = request(uri);
-    r.on('response', function(resp) {
+    //accounts for sub-folders in the file name for the key in S3
+    let filepath = filename.substring(0, filename.lastIndexOf('/'))
+    mkDirByPathSync('/tmp/fetch_upload_s3/'+filepath);
+    var file =  fs.createWriteStream('/tmp/fetch_upload_s3/'+filename);
+
+    var myrequest = got.stream(uri).pipe(file)
+    .on('response', function(resp) {
         if (resp.statusCode === 200) {
-            var download_stream = fs.createWriteStream('./.tmp/fetch_upload_s3/'+filename);
-            download_stream.on('close', done);
-            r.pipe(download_stream);
+            return done(null)
         }
         else {
             done(new Error('error: '+resp.statusCode));
         }
+    })
+
+    file.on('finish', function() {
+      file.close(done);  // close() is async, call cb after close completes.
+    });
+
+    file.on('error', function(err) { // Handle errors
+      fs.unlink('/tmp/fetch_upload_s3/'+filename); // Delete the file async. (But we don't check the result)
+      return done(err.message);
     });
 };

--- a/lib/fetch-upload-s3.js
+++ b/lib/fetch-upload-s3.js
@@ -43,7 +43,7 @@ FUS3.prototype.do = function (resource_to_fetch_url, s3_key, done) {
     if (err) {
       return done(err);
     }
-    var file_path = './.tmp/fetch_upload_s3/'+s3_key;
+    var file_path = '/tmp/fetch_upload_s3/'+s3_key;
     self.bucket.upload(file_path, s3_key, function(err) {
       if (err) {
         return done(err);
@@ -69,5 +69,3 @@ FUS3.prototype.uploadFile = function(absolutePath, s3_key, done) {
 FUS3.prototype.downloadFile = download;
 
 module.exports = FUS3;
-
-

--- a/lib/init_tmp.js
+++ b/lib/init_tmp.js
@@ -1,10 +1,8 @@
 var fs = require('fs');
 
 module.exports = function(done) {
-  exists_or_mkdir('./.tmp', function() {
-    exists_or_mkdir('./.tmp/fetch_upload_s3', function() {
-      done();
-    });
+  exists_or_mkdir('/tmp/fetch_upload_s3', function() {
+    done();
   });
 };
 

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "url": "https://github.com/saintmac/fetch-upload-s3/issues"
   },
   "dependencies": {
-    "request": "~2.27.0",
+    "async": "~0.2.9",
     "aws-sdk": "~1.9.0",
-    "async": "~0.2.9"
+    "got": "^8.3.1",
+    "is-lambda": "^1.0.1"
   },
   "devDependencies": {
     "chai": "~1.8.1",

--- a/test/1.init_tmp.js
+++ b/test/1.init_tmp.js
@@ -5,9 +5,9 @@ var should = require('chai').should(),
 
 describe('init_tmp', function(){
   before(function(done){
-    rimraf('./.tmp', function(err) {
+    rimraf('/tmp/fetch_upload_s3', function(err) {
       if (err) {
-        console.log('an error occured while removing ./.tmp: '+err);
+        console.log('an error occured while removing /tmp/fetch_upload_s3: '+err);
       }
       done(err);
     });
@@ -18,8 +18,8 @@ describe('init_tmp', function(){
   });
 
   describe('first run', function(){
-    it('should have created ./.tmp/fetch_upload_s3', function(done){
-      fs.exists('./.tmp/fetch_upload_s3', function(exists){
+    it('should have created /tmp/fetch_upload_s3', function(done){
+      fs.exists('/tmp/fetch_upload_s3', function(exists){
         exists.should.be.true;
         done();
       });
@@ -28,7 +28,7 @@ describe('init_tmp', function(){
 
   describe('second run', function(){
     it('it should not timeout', function(done){
-      fs.exists('./.tmp/fetch_upload_s3', function(exists){
+      fs.exists('/tmp/fetch_upload_s3', function(exists){
         exists.should.be.true;
         done();
       });

--- a/test/2.download_test.js
+++ b/test/2.download_test.js
@@ -13,7 +13,7 @@ describe('download', function(){
       });
 
       it('should NOT have created the file', function(done) {
-          fs.exists('./.tmp/fetch_upload_s3/404.png', function(exists){
+          fs.exists('/tmp/fetch_upload_s3/404.png', function(exists){
               exists.should.be.false;
               done()
           });
@@ -28,7 +28,7 @@ describe('download', function(){
       });
 
       it('should have created the file', function(done) {
-          fs.exists('./.tmp/fetch_upload_s3/google.png', function(exists){
+          fs.exists('/tmp/fetch_upload_s3/google.png', function(exists){
               exists.should.be.true;
               done()
           });

--- a/test/3.bucket_test.js
+++ b/test/3.bucket_test.js
@@ -36,7 +36,7 @@ describe('writing to S3', function(){
 
     describe('uploading to the bucket', function(done){
       before(function(done){
-        this.s3_bucket.upload('./.tmp/fetch_upload_s3/npm_logo.png', this.s3_key, done);
+        this.s3_bucket.upload('/tmp/fetch_upload_s3/npm_logo.png', this.s3_key, done);
       });
 
       it('should use an existing bucket', function(done){
@@ -93,5 +93,3 @@ describe('writing to S3', function(){
     });
   });
 });
-
-

--- a/test/4.fus3_test.js
+++ b/test/4.fus3_test.js
@@ -13,7 +13,7 @@ describe('fetch and upload to S3', function() {
 
   describe('init', function() {
     it('should have created .tmp/fetch_upload_s3', function(done){
-      fs.exists('./.tmp/fetch_upload_s3', function(exists){
+      fs.exists('/tmp/fetch_upload_s3', function(exists){
         exists.should.be.true;
         done();
       });
@@ -41,7 +41,7 @@ describe('fetch and upload to S3', function() {
     });
 
     it('should not keep the local copy', function(done){
-      fs.exists('./.tmp/fetch_upload_s3/'+this.s3_key, function(exists){
+      fs.exists('/tmp/fetch_upload_s3/'+this.s3_key, function(exists){
         exists.should.be.false;
         done();
       });


### PR DESCRIPTION
This pull request contains:

* the upstream S3 subfolder support
* change from `./tmp/` to `/tmp` for temporary storage (required for AWS Lambda)
* switched from request to [got](https://github.com/sindresorhus/got) because it handles gzip encoding automatically.
* an updated readme with clearer examples of how to use the library

I'm a _complete_ noob when it comes to Node so I recommend reviewing my changes. They're fairly minimal but significantly enhance the usefulness of this library.